### PR TITLE
:beetle: remove missing files from POTFILES

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -3,3 +3,4 @@ data/io.github.cleomenezesjr.Escambo.appdata.xml.in
 data/io.github.cleomenezesjr.Escambo.gschema.xml
 src/main.py
 src/window.py
+src/gtk/window.blp

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -3,4 +3,3 @@ data/io.github.cleomenezesjr.Escambo.appdata.xml.in
 data/io.github.cleomenezesjr.Escambo.gschema.xml
 src/main.py
 src/window.py
-src/window.ui


### PR DESCRIPTION
Fixes a bug I found when following https://github.com/CleoMenezesJr/escambo/pull/35#issuecomment-1554056491, which caused the PO template generation to file, as `src/window.ui` seems to longer exist. Removing it from `po/POTFILES` fixes the error.

```
ninja: Entering directory `build'
[0/1] Running external command escambo-update-po

xgettext: warning: file 'src/window.ui' extension 'ui' is unknown; will try C
xgettext: error while opening "src/window.ui" for reading: No such file or directory
FAILED: meson-internal__escambo-update-po 
```