### PR TITLE
:lipstick: Make headerbars flat where appropriate

### DIFF
--- a/src/gtk/window.blp
+++ b/src/gtk/window.blp
@@ -21,6 +21,9 @@ template $EscamboWindow : Adw.ApplicationWindow {
                             stack: stack;
                             title: bind template.title;
                         };
+                    styles [
+                      "flat",
+                    ]
                     [end]
                     MenuButton {
                         icon-name: "open-menu-symbolic";
@@ -471,6 +474,9 @@ template $EscamboWindow : Adw.ApplicationWindow {
                         Adw.WindowTitle {
                             title: "Form Data";
                         };
+                        styles [
+                          "flat",
+                        ]
 
                         [start]
                         Button {
@@ -524,6 +530,9 @@ template $EscamboWindow : Adw.ApplicationWindow {
                         Adw.WindowTitle {
                             title: "Edit Parameters";
                         };
+                        styles [
+                          "flat",
+                        ]
 
                         [start]
                         Button {


### PR DESCRIPTION
*Note: The flat style will be deprecated with the release of Adw 1.4, and should then be replaced by Adw.ToolbarView. Until then, the flat style will have to suffice.